### PR TITLE
Change Dockerfile to use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,35 @@
-FROM ubuntu:18.04
-MAINTAINER me@mehthehedgehog.be
+FROM ubuntu:19.04 as builder
 
 RUN apt-get update && \
-    apt-get install -y sudo gcc g++ python git zlib1g-dev pciutils \
-                       vim kmod strace wget curl iproute2 tcpdump \
-                       iputils-arping iputils-clockdiff iputils-ping \
-                       iputils-tracepath inetutils-traceroute mtr && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ python zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /src/trex-core
 WORKDIR /src/trex-core
 
-RUN mv ./docker/bin/entrypoint.sh /usr/bin/entrypoint.sh && \
-    mv ./docker/etc/trex_cfg.yaml /etc/trex_cfg.yaml
-
 RUN cd ./linux_dpdk && \
     ./b configure && \
-    ./b build
+    ./b build && \
+    cd ../ && \
+    rm -rf scripts/*.txt && \
+    rm -rf scripts/_t-rex-64* && \
+    cp linux_dpdk/build_dpdk/linux_dpdk/_t-rex-64* scripts/ && \
+    rm -rf scripts/so/lib*.so && \
+    cp linux_dpdk/build_dpdk/linux_dpdk/lib* scripts/so/
+
+FROM ubuntu:19.04
+
+RUN apt-get update && \
+    apt-get install -y sudo python git zlib1g-dev pciutils vim kmod \
+                       strace wget curl iproute2 iptables tcpdump \
+                       iputils-arping iputils-clockdiff iputils-ping \
+                       iputils-tracepath inetutils-traceroute mtr && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY docker/bin/entrypoint.sh /usr/bin/entrypoint.sh
+COPY docker/etc/trex_cfg.yaml /etc/trex_cfg.yaml
+COPY --from=builder /src/trex-core/scripts /src/trex-core/scripts
 
 WORKDIR /src/trex-core/scripts
 


### PR DESCRIPTION
I reduced image size for about 1 GB (773 MB vs 1.74 GB). I compared container's `/src/trex-core/scripts` directory with content of T-rex-2.65 release and there are some differences:
T-rex release contains:

1.  Simulators (`bp-sim-64` and `bp-sim-64-debug`).
2. Two additional files: `astf_async.py` and `astf_example2.py`in `automation/trex_control_plane/interactive/trex/examples/astf/`.
3. Some XML reports in `automation/regression/reports/` but I think it is not important.
4. Additional files in `astf/`: `nat.py`, `todd.py`, `todd.py`, `http_simple_todd.py`, `http_manual_todd.py`.
5. `trex_client_v2.65.tar.gz` archive.

Also, there are some additional files in the container:
- `trex_show_threads.py`
- `stty_r`
- `nginx_wget.py`
- `t-rex-64-debug-gdb-core`
- `t-rex-64-debug-o-gdb`
- `t-rex-64-valgrind`
- `t-rex-64-debug-gdb-bt`
- some compiled python `.pyc` files

I think we don't need simulators and couple of files on container should not be a problem. I think the same for lacking trex client archive since it is packed anyway. I am attaching the lists of files.

I removed `MAINTAINER` because I got hint it's deprecated, but if @MehTheHedgehog wants to keep it we can keep it.
[container-file-list.txt](https://github.com/codilime/trex-core/files/3735094/container-file-list.txt)
[t-rex-release-file-list.txt](https://github.com/codilime/trex-core/files/3735096/t-rex-release-file-list.txt)


