### PR TITLE
Add parameters for timestamping and time synchronisation configuration

### DIFF
--- a/docker/etc/trex_cfg.yaml
+++ b/docker/etc/trex_cfg.yaml
@@ -7,5 +7,4 @@
                    default_gw : 242.2.2.2
                  - ip         : 242.2.2.2
                    default_gw : 241.1.1.1
-  timesync_method: "ptp"
-  timesync_period: 300
+  latency_measurement: "nanoseconds"

--- a/docker/etc/trex_cfg.yaml
+++ b/docker/etc/trex_cfg.yaml
@@ -7,3 +7,5 @@
                    default_gw : 242.2.2.2
                  - ip         : 242.2.2.2
                    default_gw : 241.1.1.1
+  timesync_method: "ptp"
+  timesync_period: 300

--- a/src/gtest/trex_stateless_gtest.cpp
+++ b/src/gtest/trex_stateless_gtest.cpp
@@ -5015,7 +5015,17 @@ stats_for_pkt calculate_stats_for_pkts(
     return stats_for_pkt(results, error_cntrs);
 }
 
-TEST(latency_stats, no_duplicates) {
+class latency_stats: public trexStlTest {
+    public:
+
+    static void SetUpTestCase() {
+        CParserOption * po = &CGlobalInfo::m_options;
+        po->m_get_latency_timestamp = &os_get_hr_tick_64;
+        po->m_timestamp_diff_to_dsec = &ptime_convert_hr_dsec;
+    }
+};
+
+TEST_F(latency_stats, no_duplicates) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 2, 0},
@@ -5026,7 +5036,7 @@ TEST(latency_stats, no_duplicates) {
     EXPECT_EQ(std::get<0>(results).get_dup_cnt(), 0);
 }
 
-TEST(latency_stats, single_duplicate) {
+TEST_F(latency_stats, single_duplicate) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 2, 0},
@@ -5038,7 +5048,7 @@ TEST(latency_stats, single_duplicate) {
     EXPECT_EQ(std::get<0>(results).get_dup_cnt(), 1);
 }
 
-TEST(latency_stats, simple_duplicates) {
+TEST_F(latency_stats, simple_duplicates) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
@@ -5054,7 +5064,7 @@ TEST(latency_stats, simple_duplicates) {
     EXPECT_EQ(std::get<0>(results).get_dup_cnt(), 3);
 }
 
-TEST(latency_stats, interleaved_duplicates) {
+TEST_F(latency_stats, interleaved_duplicates) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 2, 0},
@@ -5071,7 +5081,7 @@ TEST(latency_stats, interleaved_duplicates) {
     EXPECT_EQ(std::get<0>(results).get_dup_cnt(), 0);
 }
 
-TEST(latency_stats, no_bad_packets) {
+TEST_F(latency_stats, no_bad_packets) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 2, 0},
@@ -5082,7 +5092,7 @@ TEST(latency_stats, no_bad_packets) {
     EXPECT_EQ(std::get<1>(results).get_bad_header(), 0);
 }
 
-TEST(latency_stats, incorrect_magic) {
+TEST_F(latency_stats, incorrect_magic) {
     constexpr auto bad_magic = decltype(flow_stat_payload_header::magic)(FLOW_STAT_PAYLOAD_MAGIC) + 1;
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
@@ -5096,7 +5106,7 @@ TEST(latency_stats, incorrect_magic) {
     EXPECT_EQ(std::get<1>(results).get_bad_header(), 2);
 }
 
-TEST(latency_stats, bad_flow) {
+TEST_F(latency_stats, bad_flow) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, MAX_FLOW_STATS_PAYLOAD, 0, 1, 0},
@@ -5107,7 +5117,7 @@ TEST(latency_stats, bad_flow) {
     EXPECT_EQ(std::get<1>(results).get_bad_header(), 1);
 }
 
-TEST(latency_stats, out_of_order) {
+TEST_F(latency_stats, out_of_order) {
     flow_stat_payload_headers fs_headers = {
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 1, 0},
         {FLOW_STAT_PAYLOAD_MAGIC, 0, 0, 3, 0},

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -214,6 +214,7 @@ enum {
        OPT_SLEEPY_SCHEDULER,
        OPT_UNBIND_UNUSED_PORTS,
        OPT_HDRH,
+       OPT_LATENCY_MEASUREMENT_METHOD,
        OPT_TIME_SYNC_METHOD,
        OPT_TIME_SYNC_PERIOD,
     
@@ -307,6 +308,7 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_NO_TERMIO,              "--no-termio",       SO_NONE},
         { OPT_QUEUE_DROP,             "--queue-drop",      SO_NONE},
         { OPT_SLEEPY_SCHEDULER,       "--sleeps",          SO_NONE},
+        { OPT_LATENCY_MEASUREMENT_METHOD, "--latency-measurement", SO_REQ_SEP},
         { OPT_TIME_SYNC_METHOD,       "--timesync-method", SO_REQ_SEP},
         { OPT_TIME_SYNC_PERIOD,       "--timesync-period", SO_REQ_SEP},
 
@@ -403,6 +405,8 @@ static int COLD_FUNC  usage() {
     printf(" --vlan                     : Relevant only for stateless mode with Intel 82599 10G NIC \n");
     printf("                              When configuring flow stat and latency per stream rules, assume all streams uses VLAN \n");
     printf(" -w  <num>                  : Wait num seconds between init of interfaces and sending traffic, default is 1 \n");
+    printf(" --latency-measurement <md> : Define what method (<md>) is be used to provide timestamps used in latency calculation. Overrides the 'latency_measurement'\n");
+    printf("                              argument from config file. Supported method are 1 for nanoseconds (clock_gettime), 0 (default) for standard system ticks (RDTSC)\n");
     printf(" --timesync-method <method> : Enable time synchronisation with given method. Overrides the 'timesync_method' argument from config file\n");
     printf("                              Supported method is 1 for PTP. Default is 0 for no synchronisation\n");
     printf(" --timesync-period <num>    : Define how often (in seconds) will time synchronisation take place. Overrides the 'timesync_period' argument from config file\n");
@@ -917,15 +921,22 @@ COLD_FUNC static int parse_options(int argc, char *argv[], bool first_time ) {
             case OPT_SLEEPY_SCHEDULER:
                 CGlobalInfo::m_options.m_is_sleepy_scheduler = true;
                 break;
+            case OPT_LATENCY_MEASUREMENT_METHOD:
+                sscanf(args.OptionArg(), "%d", &tmp_data);
+                if (! po->is_valid_opt_val(tmp_data, CParserOption::LATENCY_METHOD_TICKS, CParserOption::LATENCY_METHOD_NANOS, "--latency-measurement")) {
+                    exit(-1);
+                }
+                CGlobalInfo::m_options.m_latency_measurement = (uint8_t)tmp_data;
+                break;
             case OPT_TIME_SYNC_METHOD:
-                sscanf(args.OptionArg(),"%d", &tmp_data);
+                sscanf(args.OptionArg(), "%d", &tmp_data);
                 if (! po->is_valid_opt_val(tmp_data, CParserOption::TIMESYNC_NONE, CParserOption::TIMESYNC_PTP, "--timesync-method")) {
                     exit(-1);
                 }
                 CGlobalInfo::m_options.m_timesync_method = (uint8_t)tmp_data;
                 break;
             case OPT_TIME_SYNC_PERIOD:
-                sscanf(args.OptionArg(),"%d", &CGlobalInfo::m_options.m_timesync_period);
+                sscanf(args.OptionArg(), "%d", &CGlobalInfo::m_options.m_timesync_period);
                 break;
 
             default:
@@ -1923,9 +1934,7 @@ HOT_FUNC int CCoreEthIFStateless::send_node_flow_stat(rte_mbuf *m, CGenNodeState
     lp_s->add_bytes(mi->pkt_len + 4); // We add 4 because of ethernet CRC
 
     if (hw_id >= MAX_FLOW_STATS) {
-        // TIME EXPERIMENT
-        // fsp_head->time_stamp = os_get_hr_tick_64();
-        fsp_head->time_stamp = get_time_epoch_nanoseconds();
+        fsp_head->time_stamp = CGlobalInfo::m_options.m_get_latency_timestamp();
 
         send_pkt_lat(lp_port, mi, lp_stats);
     } else {
@@ -5969,9 +5978,16 @@ COLD_FUNC int update_global_info_from_platform_file(){
         }
     }
 
+    if (cg->m_latency_measurement.length()) {
+        if ((cg->m_latency_measurement.compare("NANOSECONDS") == 0) ||
+            (cg->m_latency_measurement.compare("1") == 0)) {
+            g_opts->m_latency_measurement = CParserOption::LATENCY_METHOD_NANOS;
+        }
+    }
+
     if (cg->m_timesync_method.length()) {
-        if ((strcasecmp(cg->m_timesync_method.c_str(), "PTP") == 0) ||
-            (strcmp(cg->m_timesync_method.c_str(), "1") == 0)) {
+        if ((cg->m_timesync_method.compare("PTP") == 0) ||
+            (cg->m_timesync_method.compare("1") == 0)) {
             g_opts->m_timesync_method = CParserOption::TIMESYNC_PTP;
         }
     }
@@ -6419,6 +6435,26 @@ COLD_FUNC int main_test(int argc , char * argv[]){
     }
 
     check_pdev_vdev_dummy();
+
+    if (CGlobalInfo::m_options.m_timesync_method == CParserOption::TIMESYNC_PTP) {
+        printf("Enabled PTP time synchronisation every %d seconds.\n", CGlobalInfo::m_options.m_timesync_period);
+    } else {
+        printf("Time synchronisation disabled.\n");
+    }
+
+    // TODO when we have a decent hardware to test the performance, it might be a good idea to implement
+    // m_get_latency_timestamp and m_timestamp_diff_to_dsec using std::function instead of simple pointers
+    // to functions and compare the performance;  there are four more CPU cycles associated with using
+    // std::function so, for the time being, we will stick to the function pointers
+    if (CGlobalInfo::m_options.m_latency_measurement == CParserOption::LATENCY_METHOD_NANOS) {
+        CGlobalInfo::m_options.m_get_latency_timestamp = &get_time_epoch_nanoseconds;
+        CGlobalInfo::m_options.m_timestamp_diff_to_dsec = &ptime_convert_ns_dsec;
+        printf("Using realtime (nanoseconds) timestamps in latency stream.\n");
+    } else {
+        CGlobalInfo::m_options.m_get_latency_timestamp = &os_get_hr_tick_64;
+        CGlobalInfo::m_options.m_timestamp_diff_to_dsec = &ptime_convert_hr_dsec;
+        printf("Using cpu ticks timestamps in latency stream.\n");
+    }
 
     if (update_dpdk_args() < 0) {
         return -1;

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -214,6 +214,8 @@ enum {
        OPT_SLEEPY_SCHEDULER,
        OPT_UNBIND_UNUSED_PORTS,
        OPT_HDRH,
+       OPT_TIME_SYNC_METHOD,
+       OPT_TIME_SYNC_PERIOD,
     
        /* no more pass this */
        OPT_MAX
@@ -305,6 +307,8 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_NO_TERMIO,              "--no-termio",       SO_NONE},
         { OPT_QUEUE_DROP,             "--queue-drop",      SO_NONE},
         { OPT_SLEEPY_SCHEDULER,       "--sleeps",          SO_NONE},
+        { OPT_TIME_SYNC_METHOD,       "--timesync-method", SO_REQ_SEP},
+        { OPT_TIME_SYNC_PERIOD,       "--timesync-period", SO_REQ_SEP},
 
         SO_END_OF_OPTIONS
     };
@@ -330,7 +334,7 @@ static int COLD_FUNC  usage() {
     printf("                              Example --active-flows 500000 wil set the ballpark of the active flow to be ~0.5M \n");
     printf(" --allow-coredump           : Allow creation of core dump \n");
     printf(" --arp-refresh-period       : Period in seconds between sending of gratuitous ARP for our addresses. Value of 0 means 'never send' \n");
-    printf(" -c <num>>                  : Number of hardware threads to allocate for each port pair. Overrides the 'c' argument from config file \n");
+    printf(" -c <num>                   : Number of hardware threads to allocate for each port pair. Overrides the 'c' argument from config file \n");
     printf(" --cfg <file>               : Use file as TRex config file instead of the default /etc/trex_cfg.yaml \n");
     printf(" --checksum-offload         : Deprecated,enable by default. Enable IP, TCP and UDP tx checksum offloading, using DPDK. This requires all used interfaces to support this  \n");
     printf(" --checksum-offload-disable : Disable IP, TCP and UDP tx checksum offloading, using DPDK. This requires all used interfaces to support this  \n");
@@ -341,7 +345,7 @@ static int COLD_FUNC  usage() {
     printf("                               so we do not call them by default for now. Leaving this as option in case someone thinks it is helpful for him \n");
     printf("                               This it temporary option. Will be removed in the future \n");
     printf(" -d                         : Duration of the test in sec (default is 3600). Look also at --nc \n");
-    printf(" -e                         : Like -p but src/dst IP will be chosen according to the port (i.e. on client port send all packets with client src and server dest, and vice versa on server port \n");
+    printf(" -e                         : Like -p but src/dst IP will be chosen according to the port (i.e. on client port send all packets with client src and server dest, and vice versa on server port) \n");
     printf(" --flip                     : Each flow will be sent both from client to server and server to client. This can achieve better port utilization when flow traffic is asymmetric \n");
     printf(" --hdrh                     : Report latency using high dynamic range histograms (http://hdrhistogram.org)\n");
     printf(" --hops <hops>              : If rx check is enabled, the hop number can be assigned. See manual for details \n");
@@ -399,6 +403,10 @@ static int COLD_FUNC  usage() {
     printf(" --vlan                     : Relevant only for stateless mode with Intel 82599 10G NIC \n");
     printf("                              When configuring flow stat and latency per stream rules, assume all streams uses VLAN \n");
     printf(" -w  <num>                  : Wait num seconds between init of interfaces and sending traffic, default is 1 \n");
+    printf(" --timesync-method <method> : Enable time synchronisation with given method. Overrides the 'timesync_method' argument from config file\n");
+    printf("                              Supported method is 1 for PTP. Default is 0 for no synchronisation\n");
+    printf(" --timesync-period <num>    : Define how often (in seconds) will time synchronisation take place. Overrides the 'timesync_period' argument from config file\n");
+    printf("                              Default is 60 seconds\n");
     
 
     printf("\n");
@@ -908,6 +916,16 @@ COLD_FUNC static int parse_options(int argc, char *argv[], bool first_time ) {
                 break;
             case OPT_SLEEPY_SCHEDULER:
                 CGlobalInfo::m_options.m_is_sleepy_scheduler = true;
+                break;
+            case OPT_TIME_SYNC_METHOD:
+                sscanf(args.OptionArg(),"%d", &tmp_data);
+                if (! po->is_valid_opt_val(tmp_data, CParserOption::TIMESYNC_NONE, CParserOption::TIMESYNC_PTP, "--timesync-method")) {
+                    exit(-1);
+                }
+                CGlobalInfo::m_options.m_timesync_method = (uint8_t)tmp_data;
+                break;
+            case OPT_TIME_SYNC_PERIOD:
+                sscanf(args.OptionArg(),"%d", &CGlobalInfo::m_options.m_timesync_period);
                 break;
 
             default:
@@ -5949,6 +5967,17 @@ COLD_FUNC int update_global_info_from_platform_file(){
                 g_opts->preview.set_vlan_mode_verify(CPreviewMode::VLAN_MODE_NORMAL);
             }
         }
+    }
+
+    if (cg->m_timesync_method.length()) {
+        if ((strcasecmp(cg->m_timesync_method.c_str(), "PTP") == 0) ||
+            (strcmp(cg->m_timesync_method.c_str(), "1") == 0)) {
+            g_opts->m_timesync_method = CParserOption::TIMESYNC_PTP;
+        }
+    }
+
+    if (cg->m_timesync_period != TIMESYNC_PERIOD_DEFAULT) {
+        g_opts->m_timesync_period = cg->m_timesync_period;
     }
 
     return (0);

--- a/src/os_time.h
+++ b/src/os_time.h
@@ -47,7 +47,6 @@ struct COsTimeGlobalData {
 
 #ifdef LINUX
 
-// TIME EXPERIMENT
 static inline uint64_t get_time_epoch_nanoseconds() {
     struct timespec res{0, 0};
     if(clock_gettime(CLOCK_REALTIME, &res) == 0) {
@@ -162,6 +161,10 @@ static inline hr_time_t ptime_convert_dsec_hr(dsec_t dsec){
 /* convert delta time */
 static inline dsec_t  ptime_convert_hr_dsec(hr_time_t hrt){
     return ((dsec_t)((double)hrt * timer_gd.m_1_div_freq ));
+}
+
+static inline dsec_t ptime_convert_ns_dsec(hr_time_t hrt){
+    return static_cast<dsec_t>(static_cast<double>(hrt) / (1000 * 1000 * 1000));
 }
 
 

--- a/src/platform_cfg.cpp
+++ b/src/platform_cfg.cpp
@@ -494,6 +494,13 @@ void operator >> (const YAML::Node& node, CPlatformYamlInfo & plat_info) {
         node["tw"] >> plat_info.m_tw;
     }
 
+    if ( node.FindValue("timesync_method") ) {
+        node["timesync_method"] >> plat_info.m_timesync_method;
+    }
+
+    if ( node.FindValue("timesync_period") ){
+        node["timesync_period"] >> plat_info.m_timesync_period;
+    }
 
     if ( node.FindValue("port_info")  ) {
         const YAML::Node& mac_info = node["port_info"];
@@ -616,6 +623,14 @@ void CPlatformYamlInfo::Dump(FILE *fd){
     }
     if (m_tx_desc) {
         fprintf(fd," m_tx_desc    :  %d \n",(int)m_tx_desc);
+    }
+
+    if (m_timesync_method.length()) {
+        fprintf(fd," timesync_method:  %s \n",m_timesync_method.c_str());
+    }
+
+    if (m_timesync_period != TIMESYNC_PERIOD_DEFAULT) {
+        fprintf(fd," timesync_period:  %d \n",(int)m_timesync_period);
     }
 
     if ( m_mac_info_exist ){

--- a/src/platform_cfg.cpp
+++ b/src/platform_cfg.cpp
@@ -19,6 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <stdlib.h>
@@ -494,8 +495,16 @@ void operator >> (const YAML::Node& node, CPlatformYamlInfo & plat_info) {
         node["tw"] >> plat_info.m_tw;
     }
 
+    if ( node.FindValue("latency_measurement") ) {
+        node["latency_measurement"] >> plat_info.m_latency_measurement;
+        std::transform(plat_info.m_latency_measurement.begin(), plat_info.m_latency_measurement.end(),
+                       plat_info.m_latency_measurement.begin(), ::toupper);
+    }
+
     if ( node.FindValue("timesync_method") ) {
         node["timesync_method"] >> plat_info.m_timesync_method;
+        std::transform(plat_info.m_timesync_method.begin(), plat_info.m_timesync_method.end(),
+                       plat_info.m_timesync_method.begin(), ::toupper);
     }
 
     if ( node.FindValue("timesync_period") ){
@@ -623,6 +632,10 @@ void CPlatformYamlInfo::Dump(FILE *fd){
     }
     if (m_tx_desc) {
         fprintf(fd," m_tx_desc    :  %d \n",(int)m_tx_desc);
+    }
+
+    if (m_latency_measurement.length()) {
+        fprintf(fd," latency_measurement:  %s \n",m_latency_measurement.c_str());
     }
 
     if (m_timesync_method.length()) {

--- a/src/platform_cfg.h
+++ b/src/platform_cfg.h
@@ -218,6 +218,7 @@ public:
         m_rx_desc =0;
         m_tx_desc =0;
 
+        m_latency_measurement = "";
         m_timesync_method = "";
         m_timesync_period = TIMESYNC_PERIOD_DEFAULT;
     }
@@ -264,6 +265,7 @@ public:
     CPlatformCoresYamlInfo      m_platform;
     CTimerWheelYamlInfo         m_tw;
 
+    std::string                 m_latency_measurement;
     std::string                 m_timesync_method;
     uint32_t                    m_timesync_period;
 

--- a/src/platform_cfg.h
+++ b/src/platform_cfg.h
@@ -33,6 +33,8 @@ limitations under the License.
 
 #define CONST_NB_MBUF_2_10G  (16380/2)
 
+#define TIMESYNC_PERIOD_DEFAULT 60
+
 typedef enum {         MBUF_64        , // per dual port, per NUMA
 
                        MBUF_128       ,
@@ -215,6 +217,9 @@ public:
         m_tw.reset();
         m_rx_desc =0;
         m_tx_desc =0;
+
+        m_timesync_method = "";
+        m_timesync_period = TIMESYNC_PERIOD_DEFAULT;
     }
 
     bool            m_info_exist; /* file exist ?*/
@@ -258,6 +263,9 @@ public:
     CPlatformMemoryYamlInfo     m_memory;
     CPlatformCoresYamlInfo      m_platform;
     CTimerWheelYamlInfo         m_tw;
+
+    std::string                 m_timesync_method;
+    uint32_t                    m_timesync_period;
 
 public:
     std::string get_use_if_comma_seperated();

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -503,6 +503,11 @@ public:
     LEARN_MODE_TCP=100
     };
 
+    enum trex_timesync_method {
+        TIMESYNC_NONE = 0,
+        TIMESYNC_PTP = 1
+    };
+
 public:
 
     void reset() {
@@ -556,6 +561,8 @@ public:
         m_dummy_count=0;
         m_reta_mask=0;
         m_hdrh = false;
+        m_timesync_method = 0;
+        m_timesync_period = 60;
     }
 
     CParserOption(){
@@ -615,7 +622,9 @@ public:
     double          m_tw_bucket_time_sec;
     double          m_tw_bucket_time_sec_level1;
     uint32_t        x710_fdir_reset_threshold;
-    
+
+    uint8_t         m_timesync_method;
+    uint32_t        m_timesync_period;
 
 
 public:

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -503,6 +503,13 @@ public:
     LEARN_MODE_TCP=100
     };
 
+    enum trex_latency_measurement_method {
+        LATENCY_METHOD_TICKS = 0,
+        // use RDTSC instruction - very fast but cannot be synchronised between two machines
+        LATENCY_METHOD_NANOS = 1
+        // use clock_gettime(CLOCK_REALTIME,) - a slower but uses synchronisable time
+    };
+
     enum trex_timesync_method {
         TIMESYNC_NONE = 0,
         TIMESYNC_PTP = 1
@@ -561,6 +568,7 @@ public:
         m_dummy_count=0;
         m_reta_mask=0;
         m_hdrh = false;
+        m_latency_measurement = 0;
         m_timesync_method = 0;
         m_timesync_period = 60;
     }
@@ -623,6 +631,9 @@ public:
     double          m_tw_bucket_time_sec_level1;
     uint32_t        x710_fdir_reset_threshold;
 
+    uint8_t         m_latency_measurement;
+    uint64_t        (*m_get_latency_timestamp)();
+    double          (*m_timestamp_diff_to_dsec)(uint64_t);
     uint8_t         m_timesync_method;
     uint32_t        m_timesync_period;
 


### PR DESCRIPTION
A new TRex parameter `--timesync-method` defines method that will be
used in time synchronisation between two TRex instances measuring
network latency.  Value `1` means TRex will be using PTP, `0` disables
time synchronisation (it is a default value).  In trex_cfg.yaml strings
`"ptp"` or `"1"` mean PTP, any other value disables synchornisation.

The second parameter added `--timesync-period` (or `timesync_period` in
trex_cfg.yaml) defines how often will time synchronisation be performed.
Its value is measured in seconds.

Command line parameters overwrite the ones from config file.