### PR TITLE
Timesync in the main loop

### DIFF
--- a/linux/ws_main.py
+++ b/linux/ws_main.py
@@ -319,7 +319,8 @@ stx_src = SrcGroup(dir='src/stx/common',
                                      'trex_stack_linux_based.cpp',
                                      'trex_stack_legacy.cpp',
                                      'trex_rx_rpc_tunnel.cpp',
-                                     'trex_rpc_cmds_common.cpp'
+                                     'trex_rpc_cmds_common.cpp',
+                                     'trex_timesync.cpp',
                                      ])
 
 
@@ -717,7 +718,3 @@ def install_single_system (bld, exec_p, build_obj):
         if not os.path.lexists(dest_file):
             print('{0} --> {1}'.format(build_obj.get_target(), relative_path))
             os.symlink(relative_path, dest_file);
-
-
-
-

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -502,6 +502,7 @@ main_src = SrcGroup(dir='src',
              'utils/utl_port_map.cpp',
              'utils/utl_sync_barrier.cpp',
              'utils/utl_term_io.cpp',
+             'utils/utl_timesync.cpp',
              'utils/utl_yaml.cpp',
              ]);
 
@@ -583,6 +584,7 @@ stx_src = SrcGroup(dir='src/stx/common/',
         'trex_rx_rpc_tunnel.cpp',
         'trex_stack_linux_based.cpp',
         'trex_stx.cpp',
+        'trex_timesync.cpp',
     ])
 
 
@@ -2180,16 +2182,3 @@ def test (ctx):
     r=getstatusoutput("git log --pretty=format:'%H' -n 1")
     if r[0]==0:
         print(r[1])
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -143,7 +143,7 @@ def options(opt):
     opt.add_option('--pkg-file', '--pkg_file', dest='pkg_file', default=False, action='store', help="Destination filename for 'pkg' option.")
     opt.add_option('--publish-commit', '--publish_commit', dest='publish_commit', default=False, action='store', help="Specify commit id for 'publish_both' option (Please make sure it's good!)")
     opt.add_option('--no-mlx', dest='no_mlx', default=(True if march == 'aarch64' else False), action='store', help="don't use mlx5 dpdk driver. use with ./b configure --no-mlx. no need to run build with it")
-    opt.add_option('--with-ntacc', dest='with_ntacc', default=False, action='store_true', help="Use Napatech dpdk driver. Use with ./b configure --with-ntacc.")    
+    opt.add_option('--with-ntacc', dest='with_ntacc', default=False, action='store_true', help="Use Napatech dpdk driver. Use with ./b configure --with-ntacc.")
     opt.add_option('--with-bird', default=False, action='store_true', help="Build Bird server. Use with ./b configure --with-bird.")
     opt.add_option('--no-ver', action = 'store_true', help = "Don't update version file.")
     opt.add_option('--no-old', action = 'store_true', help = "Don't build old targets.")
@@ -152,7 +152,7 @@ def options(opt):
     co = opt.option_groups['configure options']
     co.add_option('--sanitized', dest='sanitized', default=False, action='store_true',
                    help='for GCC {0}+ use address sanitizer to catch memory errors'.format(SANITIZE_CC_VERSION))
-    
+
     co.add_option('--gcc6', dest='gcc6', default=False, action='store_true',
                    help='use GCC 6.2 instead of the machine version')
 
@@ -252,12 +252,12 @@ def check_ntapi(ctx):
     ctx.end_msg('Found needed NTAPI library')
     return True
 
-    
+
 def verify_cc_version (env, min_ver = REQUIRED_CC_VERSION):
     ver = StrictVersion('.'.join(env['CC_VERSION']))
 
     return (ver >= min_ver, ver, min_ver)
-    
+
 
 @conf
 def get_ld_search_path(ctx):
@@ -321,9 +321,9 @@ def configure(conf):
     with_ntacc      = conf.options.with_ntacc
     with_bird       = conf.options.with_bird
     with_sanitized  = conf.options.sanitized
-    
+
     configure_sanitized(conf, with_sanitized)
-            
+
     conf.env.NO_MLX = no_mlx
     if not no_mlx:
         ofed_ok = conf.check_ofed(mandatory = False)
@@ -383,7 +383,7 @@ def configure_gcc(conf, explicit_paths = None):
         conf.environ['PATH'] = explicit_path
         load_compiler(conf)
     finally:
-        conf.environ['PATH'] = saved 
+        conf.environ['PATH'] = saved
 
 
 
@@ -393,7 +393,7 @@ def configure_sanitized (conf, with_sanitized):
     conf.env.SANITIZED = False
 
     # if sanitized is required - check GCC version for sanitizing
-    conf.start_msg('Build sanitized images (GCC >= {0})'.format(SANITIZE_CC_VERSION))    
+    conf.start_msg('Build sanitized images (GCC >= {0})'.format(SANITIZE_CC_VERSION))
 
     # not required
     if not with_sanitized:
@@ -502,7 +502,6 @@ main_src = SrcGroup(dir='src',
              'utils/utl_port_map.cpp',
              'utils/utl_sync_barrier.cpp',
              'utils/utl_term_io.cpp',
-             'utils/utl_timesync.cpp',
              'utils/utl_yaml.cpp',
              ]);
 
@@ -601,14 +600,14 @@ stateless_src = SrcGroup(dir='src/stx/stl/',
                                     'trex_stl_port.cpp',
                                     'trex_stl_streams_compiler.cpp',
                                     'trex_stl_vm_splitter.cpp',
-                                    
+
                                     'trex_stl_dp_core.cpp',
                                     'trex_stl_fs.cpp',
-                                    
+
                                     'trex_stl_messaging.cpp',
-                                    
+
                                     'trex_stl_rpc_cmds.cpp'
-                                    
+
                                     ])
 
 
@@ -762,7 +761,7 @@ dpdk_src_x86_64 = SrcGroup(dir='src/dpdk/',
                  'drivers/net/failsafe/failsafe_flow.c',
                  'drivers/net/failsafe/failsafe_intr.c',
 
-                 #tap 
+                 #tap
 
                  'drivers/net/tap/rte_eth_tap.c',
                  'drivers/net/tap/tap_flow.c',
@@ -1142,7 +1141,7 @@ common_flags = ['-DWIN_UCODE_SIM',
 if march == 'x86_64':
     common_flags_new = common_flags + [
                     '-march=native',
-                    '-mssse3', '-msse4.1', '-mpclmul', 
+                    '-mssse3', '-msse4.1', '-mpclmul',
                     '-DRTE_MACHINE_CPUFLAG_SSE',
                     '-DRTE_MACHINE_CPUFLAG_SSE2',
                     '-DRTE_MACHINE_CPUFLAG_SSE3',
@@ -1254,7 +1253,7 @@ dpdk_includes_path =''' ../src/
                         ../src/dpdk/drivers/net/ena/
                         ../src/dpdk/drivers/net/ena/base/
                         ../src/dpdk/drivers/net/ena/base/ena_defs/
-                         
+
                         ../src/dpdk/lib/
                         ../src/dpdk/lib/librte_cfgfile/
                         ../src/dpdk/lib/librte_compat/
@@ -1281,7 +1280,7 @@ dpdk_includes_path =''' ../src/
                         ../src/dpdk/lib/librte_ring/
                         ../src/dpdk/lib/librte_timer/
                         ../src/dpdk/
-                        
+
                         ../src/dpdk/drivers/bus/pci/
                         ../src/dpdk/drivers/bus/vdev/
                         ../src/dpdk/drivers/bus/pci/linux/
@@ -1362,11 +1361,11 @@ class build_option:
         self.env = env;
 
     def is_clang(self):
-        if self.env: 
+        if self.env:
             if 'clang' in self.env[0]:
                 return True
-        return False        
-      
+        return False
+
     def __str__(self):
        s=self.mode+","+self.platform;
        return (s);
@@ -1528,11 +1527,11 @@ class build_option:
 
         return (flags)
 
-        
+
     def get_c_flags (self, is_sanitized):
-        
+
         flags = self.get_common_flags()
-        
+
         if  self.isRelease () :
             flags += ['-DNDEBUG'];
 
@@ -1549,7 +1548,7 @@ class build_option:
         # for C no special flags yet
         return (flags)
 
-        
+
     def get_link_flags(self, is_sanitized):
         base_flags = ['-rdynamic'];
         if self.is64Platform() and self.isIntelPlatform():
@@ -1589,13 +1588,13 @@ def build_prog (bld, build_obj):
     debug_file_list='';
     #if not build_obj.isRelease ():
     #    debug_file_list +=ef_src.file_list(top)
-    
+
     build_obj.set_env(bld.env.CXX)
 
     cflags    = build_obj.get_c_flags(bld.env.SANITIZED)
     cxxflags  = build_obj.get_cxx_flags(bld.env.SANITIZED)
     linkflags = build_obj.get_link_flags(bld.env.SANITIZED)
-    
+
     bld.objects(
       features='c ',
       includes = dpdk_includes_path,
@@ -2046,7 +2045,7 @@ def fix_pkg_include(bld):
         pkg_include.append('bird')
 
 def release(ctx, custom_dir = None):
-    
+
     bld = Build.BuildContext()
     bld.load_envs()
 

--- a/src/bp_sim.cpp
+++ b/src/bp_sim.cpp
@@ -34,6 +34,7 @@ limitations under the License.
 
 #include "trex_stx.h"
 #include "utl_mbuf.h"
+#include "utl_timesync.h"
 
 /* stateless includes */
 #include "stl/trex_stl_stream_node.h"
@@ -3806,6 +3807,32 @@ void CNodeGenerator::handle_pcap_pkt(CGenNode *node, CFlowGenListPerThread *thre
     }
 }
 
+void CNodeGenerator::handle_timesync_msg(CGenNodeTimesync *node, CFlowGenListPerThread *thread, bool &exit_scheduler) {
+    printf("MATEUSZ CNodeGenerator::handle_timesync_msg (PTP master) #0\n");
+    
+    /* first pop the node */
+    m_p_queue.pop();
+
+    /* exit in case this is the last node*/
+    if ( m_p_queue.size() == m_parent->m_non_active_nodes ) {
+        thread->free_node((CGenNode *)node);
+        exit_scheduler = true;
+    } else {
+        dsec_t cur_time = now_sec();
+        printf("MATEUSZ CNodeGenerator::handle_timesync_msg (PTP master) #1\ttimesync_last = %g\ttimesync_interval = %d\tcur_time = %g\n",
+            node->timesync_last, CGlobalInfo::m_options.m_timesync_interval, cur_time);
+        if (node->timesync_last + (double) CGlobalInfo::m_options.m_timesync_interval < cur_time) {
+            // do the timesyncing
+            printf("MATEUSZ CNodeGenerator::handle_timesync_msg (PTP master) #2\n");
+            node->timesync_last = do_timesync(cur_time);  // thread?
+        }
+        /* schedule for next time synchronization check */
+        node->m_time += SYNC_TIME_OUT;
+        m_p_queue.push((CGenNode *)node);
+    }
+    printf("MATEUSZ CNodeGenerator::handle_timesync_msg (PTP master) #3\n");
+}
+
 bool
 CNodeGenerator::handle_slow_messages(uint8_t type,
                                      CGenNode * node,
@@ -3863,6 +3890,10 @@ CNodeGenerator::handle_slow_messages(uint8_t type,
 
     case CGenNode::STL_RX_FLUSH:
         thread->handle_stl_rx(node,on_terminate);
+        break;
+
+    case CGenNode::TIMESYNC:
+        handle_timesync_msg((CGenNodeTimesync *)node, thread, exit_scheduler);
         break;
 
     default:

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -543,7 +543,8 @@ public:
         NODE_FLAGS_INIT_START_FROM_SERVER_SIDE = 0x40,
         NODE_FLAGS_ALL_FLOW_SAME_PORT_SIDE     = 0x80,
         NODE_FLAGS_INIT_START_FROM_SERVER_SIDE_SERVER_ADDR = 0x100, /* init packet start from server side with server addr */
-        NODE_FLAGS_SLOW_PATH = 0x200 /* used by the nodes to differ between fast path nodes and slow path nodes */
+        NODE_FLAGS_SLOW_PATH = 0x200, /* used by the nodes to differ between fast path nodes and slow path nodes */
+        NODE_FLAGS_SEND_IMMEDIATELY = 0x400 /* used by the nodes to flag as need to send immediately */
     };
 
 
@@ -592,6 +593,18 @@ public:
 
     inline bool get_is_slow_path() const {
         return ( (m_flags & NODE_FLAGS_SLOW_PATH) ? true : false);
+    }
+    
+    inline void set_send_immediately(bool enable) {
+        if (enable) {
+            m_flags |= NODE_FLAGS_SEND_IMMEDIATELY;
+        } else {
+            m_flags &= ~NODE_FLAGS_SEND_IMMEDIATELY;
+        }
+    }
+
+    inline bool should_send_immediately() const {
+        return ( (m_flags & NODE_FLAGS_SEND_IMMEDIATELY) ? true : false);
     }
 
     void free_base();

--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -526,6 +526,8 @@ public:
 
         RX_MSG                  =16,  /* message to Rx core */
         STL_RX_FLUSH            =17,
+
+        TIMESYNC                =18,
     };
 
     /* flags MASKS*/
@@ -1285,6 +1287,7 @@ private:
     void handle_pcap_pkt(CGenNode *node, CFlowGenListPerThread *thread);
     void handle_maintenance(CFlowGenListPerThread *thread);
     void handle_batch_tw_level1(CGenNode *node, CFlowGenListPerThread *thread,bool &exit_scheduler,bool on_terminate);
+    void handle_timesync_msg(CGenNodeTimesync *node, CFlowGenListPerThread *thread, bool &exit_scheduler);
 
 
 public:

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -311,7 +311,7 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_SLEEPY_SCHEDULER,       "--sleeps",          SO_NONE},
         { OPT_LATENCY_MEASUREMENT_METHOD, "--latency-measurement", SO_REQ_SEP},
         { OPT_TIME_SYNC_METHOD,       "--timesync-method", SO_REQ_SEP},
-        { OPT_TIME_SYNC_PERIOD,       "--timesync-period", SO_REQ_SEP},
+        { OPT_TIME_SYNC_PERIOD,       "--timesync-interval", SO_REQ_SEP},
 
         SO_END_OF_OPTIONS
     };
@@ -410,8 +410,8 @@ static int COLD_FUNC  usage() {
     printf("                              argument from config file. Supported method are 1 for nanoseconds (clock_gettime), 0 (default) for standard system ticks (RDTSC)\n");
     printf(" --timesync-method <method> : Enable time synchronisation with given method. Overrides the 'timesync_method' argument from config file\n");
     printf("                              Supported method is 1 for PTP. Default is 0 for no synchronisation\n");
-    printf(" --timesync-period <num>    : Define how often (in seconds) will time synchronisation take place. Overrides the 'timesync_period' argument from config file\n");
-    printf("                              Default is 60 seconds\n");
+    printf(" --timesync-interval <num>  : Define how often (in seconds) will time synchronisation take place. Overrides the 'timesync_interval' argument from config file\n");
+    printf("                              Default is 0 seconds which means TRex will be running as a client/slave in time synchronisation protocol.\n");
     
 
     printf("\n");
@@ -937,7 +937,7 @@ COLD_FUNC static int parse_options(int argc, char *argv[], bool first_time ) {
                 CGlobalInfo::m_options.m_timesync_method = (uint8_t)tmp_data;
                 break;
             case OPT_TIME_SYNC_PERIOD:
-                sscanf(args.OptionArg(), "%d", &CGlobalInfo::m_options.m_timesync_period);
+                sscanf(args.OptionArg(), "%d", &CGlobalInfo::m_options.m_timesync_interval);
                 break;
 
             default:
@@ -5978,8 +5978,8 @@ COLD_FUNC int update_global_info_from_platform_file(){
         }
     }
 
-    if (cg->m_timesync_period != TIMESYNC_PERIOD_DEFAULT) {
-        g_opts->m_timesync_period = cg->m_timesync_period;
+    if (cg->m_timesync_interval != TIMESYNC_INTERVAL_DEFAULT) {
+        g_opts->m_timesync_interval = cg->m_timesync_interval;
     }
 
     return (0);
@@ -6424,7 +6424,11 @@ COLD_FUNC int main_test(int argc , char * argv[]){
     check_pdev_vdev_dummy();
 
     if (CGlobalInfo::m_options.m_timesync_method == CParserOption::TIMESYNC_PTP) {
-        printf("Enabled PTP time synchronisation every %d seconds.\n", CGlobalInfo::m_options.m_timesync_period);
+        if (CGlobalInfo::m_options.m_timesync_interval == 0) {
+            printf("Enabled PTP time synchronisation (as slave).\n");
+        } else {
+            printf("Enabled PTP time synchronisation every %d seconds (as master).\n", CGlobalInfo::m_options.m_timesync_interval);
+        }
     } else {
         printf("Time synchronisation disabled.\n");
     }

--- a/src/platform_cfg.cpp
+++ b/src/platform_cfg.cpp
@@ -507,8 +507,8 @@ void operator >> (const YAML::Node& node, CPlatformYamlInfo & plat_info) {
                        plat_info.m_timesync_method.begin(), ::toupper);
     }
 
-    if ( node.FindValue("timesync_period") ){
-        node["timesync_period"] >> plat_info.m_timesync_period;
+    if ( node.FindValue("timesync_interval") ){
+        node["timesync_interval"] >> plat_info.m_timesync_interval;
     }
 
     if ( node.FindValue("port_info")  ) {
@@ -642,8 +642,8 @@ void CPlatformYamlInfo::Dump(FILE *fd){
         fprintf(fd," timesync_method:  %s \n",m_timesync_method.c_str());
     }
 
-    if (m_timesync_period != TIMESYNC_PERIOD_DEFAULT) {
-        fprintf(fd," timesync_period:  %d \n",(int)m_timesync_period);
+    if (m_timesync_interval != TIMESYNC_INTERVAL_DEFAULT) {
+        fprintf(fd," timesync_interval:  %d \n",(int)m_timesync_interval);
     }
 
     if ( m_mac_info_exist ){

--- a/src/platform_cfg.h
+++ b/src/platform_cfg.h
@@ -33,7 +33,7 @@ limitations under the License.
 
 #define CONST_NB_MBUF_2_10G  (16380/2)
 
-#define TIMESYNC_PERIOD_DEFAULT 60
+#define TIMESYNC_INTERVAL_DEFAULT 0
 
 typedef enum {         MBUF_64        , // per dual port, per NUMA
 
@@ -220,7 +220,7 @@ public:
 
         m_latency_measurement = "";
         m_timesync_method = "";
-        m_timesync_period = TIMESYNC_PERIOD_DEFAULT;
+        m_timesync_interval = TIMESYNC_INTERVAL_DEFAULT;
     }
 
     bool            m_info_exist; /* file exist ?*/
@@ -267,7 +267,7 @@ public:
 
     std::string                 m_latency_measurement;
     std::string                 m_timesync_method;
-    uint32_t                    m_timesync_period;
+    uint32_t                    m_timesync_interval;
 
 public:
     std::string get_use_if_comma_seperated();

--- a/src/stx/common/trex_rx_core.cpp
+++ b/src/stx/common/trex_rx_core.cpp
@@ -463,6 +463,12 @@ void
 CRxCore::enable_latency() {
     for (auto &mngr_pair : m_rx_port_mngr_map) {
         mngr_pair.second->enable_latency();
+        // This is a sending part for time synchronisation.  Enable it only if `timesync-method`
+        // is set and `timesync-interval` equals 0.
+        if ((CGlobalInfo::m_options.m_timesync_method != CParserOption::TIMESYNC_NONE) &&
+            (CGlobalInfo::m_options.m_timesync_interval == 0)) {
+            mngr_pair.second->enable_timesync(CGlobalInfo::m_options.m_timesync_method);
+        }
     }
     
     recalculate_next_state();
@@ -481,6 +487,9 @@ CRxCore::enable_astf_latency_fia(bool enable) {
 void
 CRxCore::disable_latency() {
     for (auto &mngr_pair : m_rx_port_mngr_map) {
+        if (CGlobalInfo::m_options.m_timesync_method != CParserOption::TIMESYNC_NONE) {
+            mngr_pair.second->disable_timesync();
+        }
         mngr_pair.second->disable_latency();
     }
     

--- a/src/stx/common/trex_rx_port_mngr.cpp
+++ b/src/stx/common/trex_rx_port_mngr.cpp
@@ -582,6 +582,10 @@ void RXPortManager::handle_pkt(rte_mbuf_t *m) {
         }
     }
 
+    if (is_feature_set(TIMESYNC)) {
+        m_timesync->handle_pkt(m, m_port_id);
+    }
+
     rte_pktmbuf_free(m);
 }
 
@@ -715,6 +719,13 @@ void RXPortManager::to_json(Json::Value &feat_res) const {
         feat_res["capwap_proxy"]["is_active"] = true;
     } else {
         feat_res["capwap_proxy"]["is_active"] = false;
+    }
+
+    if (is_feature_set(TIMESYNC)) {
+        feat_res["timesync"] = m_timesync->to_json();
+        feat_res["timesync"]["is_active"] = true;
+    } else {
+        feat_res["timesync"]["is_active"] = false;
     }
 
 }

--- a/src/stx/common/trex_rx_port_mngr.h
+++ b/src/stx/common/trex_rx_port_mngr.h
@@ -31,6 +31,7 @@
 #include "trex_rx_feature_api.h"
 #include "trex_stack_base.h"
 #include "trex_latency_counters.h"
+#include "trex_timesync.h"
 
 class CPortLatencyHWBase;
 class BPFFilter;
@@ -240,7 +241,8 @@ public:
         STACK        = 1 << 2,
         CAPTURE_PORT = 1 << 3,
         CAPWAP_PROXY = 1 << 4,
-        ASTF_LATENCY = 1 << 5
+        ASTF_LATENCY = 1 << 5,
+        TIMESYNC     = 1 << 6
     };
 
     RXPortManager();
@@ -303,6 +305,18 @@ public:
     void stop_queue() {
         m_queue.stop();
         unset_feature(QUEUE); 
+    }
+
+    /* timesync */
+    void enable_timesync(uint8_t timesync_method) {
+        printf("MATEUSZ RXPortManager::enable_timesync (%d)\n", timesync_method);
+        m_timesync = new RXTimesync(timesync_method);
+        set_feature(TIMESYNC);
+    }
+
+    void disable_timesync() {
+        printf("MATEUSZ RXPortManager::disable_timesync\n");
+        unset_feature(TIMESYNC);
     }
 
     const TrexPktBuffer *get_pkt_buffer() {
@@ -447,6 +461,8 @@ private:
     CRXCoreIgnoreStat            m_ign_stats_prev;
 
     RXFeatureAPI                 m_feature_api;
+
+    RXTimesync                  *m_timesync;
 };
 
 

--- a/src/stx/common/trex_rx_port_mngr.h
+++ b/src/stx/common/trex_rx_port_mngr.h
@@ -309,13 +309,11 @@ public:
 
     /* timesync */
     void enable_timesync(uint8_t timesync_method) {
-        printf("MATEUSZ RXPortManager::enable_timesync (%d)\n", timesync_method);
         m_timesync = new RXTimesync(timesync_method);
         set_feature(TIMESYNC);
     }
 
     void disable_timesync() {
-        printf("MATEUSZ RXPortManager::disable_timesync\n");
         unset_feature(TIMESYNC);
     }
 

--- a/src/stx/common/trex_timesync.cpp
+++ b/src/stx/common/trex_timesync.cpp
@@ -1,0 +1,19 @@
+#include "trex_timesync.h"
+
+#include "trex_global.h"
+
+/**************************************
+ * RXTimesync
+ *************************************/
+// RXTimesync::RXTimesync() {}
+
+void RXTimesync::handle_pkt(const rte_mbuf_t *m, int port) {
+    if (m_timesync_method == CParserOption::TIMESYNC_PTP) {
+        printf("Syncing time with PTP method (slave side).\n");
+#ifdef _DEBUG
+        printf("PTP time synchronisation is currently not supported (but we are working on that).\n");
+#endif
+    }
+}
+
+Json::Value RXTimesync::to_json() const { return Json::objectValue; }

--- a/src/stx/common/trex_timesync.h
+++ b/src/stx/common/trex_timesync.h
@@ -1,0 +1,21 @@
+#ifndef __TREX_TIMESYNC_H__
+#define __TREX_TIMESYNC_H__
+
+#include "stl/trex_stl_fs.h"
+
+/**************************************
+ * RXTimesync
+ *************************************/
+class RXTimesync {
+  public:
+    RXTimesync(uint8_t timesync_method) { m_timesync_method = timesync_method; };
+
+    void handle_pkt(const rte_mbuf_t *m, int port);
+
+    Json::Value to_json() const;
+
+  private:
+    uint8_t m_timesync_method;
+};
+
+#endif

--- a/src/stx/stl/trex_stl_dp_core.cpp
+++ b/src/stx/stl/trex_stl_dp_core.cpp
@@ -1009,6 +1009,8 @@ bool TrexStatelessDpCore::set_stateless_next_node(CGenNodeStateless * cur_node,
 void
 TrexStatelessDpCore::start_scheduler() {
 
+    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #0\n");
+
     /* creates a maintenace job using the scheduler */
     CGenNode * node_sync = m_core->create_node() ;
     node_sync->m_type = CGenNode::FLOW_SYNC;
@@ -1016,6 +1018,7 @@ TrexStatelessDpCore::start_scheduler() {
 
     m_core->m_node_gen.add_node(node_sync);
 
+    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #1\n");
     if ( get_dpdk_mode()->dp_rx_queues() ){
         // add rx node if needed
         CGenNode * node_rx = m_core->create_node() ;
@@ -1024,6 +1027,20 @@ TrexStatelessDpCore::start_scheduler() {
         m_core->m_node_gen.add_node(node_rx);
     }
 
+    if ((CGlobalInfo::m_options.m_timesync_method != CParserOption::TIMESYNC_NONE) &&
+        (CGlobalInfo::m_options.m_timesync_interval > 0)) {
+        // This is a sending part for time synchronisation.  Enable it only if
+        // `timesync-method` is set and and `timesync-interval` is greater than 0.
+        printf("MATEUSZ TrexStatelessDpCore::start_scheduler #2\n");
+        CGenNodeTimesync *node_timesync = (CGenNodeTimesync *)m_core->create_node();
+        node_timesync->m_type = CGenNode::TIMESYNC;
+        node_timesync->m_time = m_core->m_cur_time_sec + SYNC_TIME_OUT;
+        node_timesync->timesync_last = -1.0 * (double)CGlobalInfo::m_options.m_timesync_interval;
+        m_core->m_node_gen.add_node((CGenNode *)node_timesync);
+        printf("MATEUSZ TrexStatelessDpCore::start_scheduler #3\n");
+    }
+
+    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #4\n");
     double old_offset = 0.0;
     m_core->m_node_gen.flush_file(-1, 0.0, false, m_core, old_offset);
     /* bail out in case of terminate */
@@ -1031,6 +1048,7 @@ TrexStatelessDpCore::start_scheduler() {
         m_core->m_node_gen.close_file(m_core);
         m_state = STATE_IDLE; /* we exit from all ports and we have nothing to do, we move to IDLE state */
     }
+    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #5\n");
 }
 
 

--- a/src/stx/stl/trex_stl_dp_core.cpp
+++ b/src/stx/stl/trex_stl_dp_core.cpp
@@ -1009,8 +1009,6 @@ bool TrexStatelessDpCore::set_stateless_next_node(CGenNodeStateless * cur_node,
 void
 TrexStatelessDpCore::start_scheduler() {
 
-    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #0\n");
-
     /* creates a maintenace job using the scheduler */
     CGenNode * node_sync = m_core->create_node() ;
     node_sync->m_type = CGenNode::FLOW_SYNC;
@@ -1018,7 +1016,6 @@ TrexStatelessDpCore::start_scheduler() {
 
     m_core->m_node_gen.add_node(node_sync);
 
-    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #1\n");
     if ( get_dpdk_mode()->dp_rx_queues() ){
         // add rx node if needed
         CGenNode * node_rx = m_core->create_node() ;
@@ -1029,18 +1026,15 @@ TrexStatelessDpCore::start_scheduler() {
 
     if ((CGlobalInfo::m_options.m_timesync_method != CParserOption::TIMESYNC_NONE) &&
         (CGlobalInfo::m_options.m_timesync_interval > 0)) {
-        // This is a sending part for time synchronisation.  Enable it only if
+        // This is a Tx part for time synchronisation.  Enable it only if
         // `timesync-method` is set and and `timesync-interval` is greater than 0.
-        printf("MATEUSZ TrexStatelessDpCore::start_scheduler #2\n");
         CGenNodeTimesync *node_timesync = (CGenNodeTimesync *)m_core->create_node();
         node_timesync->m_type = CGenNode::TIMESYNC;
         node_timesync->m_time = m_core->m_cur_time_sec + SYNC_TIME_OUT;
         node_timesync->timesync_last = -1.0 * (double)CGlobalInfo::m_options.m_timesync_interval;
         m_core->m_node_gen.add_node((CGenNode *)node_timesync);
-        printf("MATEUSZ TrexStatelessDpCore::start_scheduler #3\n");
     }
 
-    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #4\n");
     double old_offset = 0.0;
     m_core->m_node_gen.flush_file(-1, 0.0, false, m_core, old_offset);
     /* bail out in case of terminate */
@@ -1048,7 +1042,6 @@ TrexStatelessDpCore::start_scheduler() {
         m_core->m_node_gen.close_file(m_core);
         m_state = STATE_IDLE; /* we exit from all ports and we have nothing to do, we move to IDLE state */
     }
-    printf("MATEUSZ TrexStatelessDpCore::start_scheduler #5\n");
 }
 
 

--- a/src/stx/stl/trex_stl_dp_core.h
+++ b/src/stx/stl/trex_stl_dp_core.h
@@ -41,6 +41,7 @@ class TrexStream;
 class CGenNodePCAP;
 class ServiceModeWrapper;
 class CFlowStatParser;
+class CGenNodeTimesync;
 
 class CDpOneStream  {
 public:

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -703,5 +703,47 @@ private:
 
 static_assert(sizeof(CGenNodePCAP) == sizeof(CGenNode), "sizeof(CGenNodePCAP) != sizeof(CGenNode)" );
 
+/* this is a event for time synchronization. */
+struct CGenNodeTimesync : public CGenNodeBase {
+    // This part if a copy of CGenNode
+    uint32_t m_src_ip;  /* client ip */
+    uint32_t m_dest_ip; /* server ip */
+
+    uint64_t m_flow_id; /* id that goes up for each flow */
+
+    /*c2*/
+    CFlowPktInfo *m_pkt_info;
+
+    CCapFileFlowInfo *m_flow_info;
+    CFlowYamlInfo *m_template_info;
+
+    void *m_plugin_info;
+
+    /* cache line -2 */
+    CHTimerObj m_tmr;
+    uint64_t m_tmr_pad[4];
+
+    /* cache line -3 */
+
+    CTupleGeneratorSmart *m_tuple_gen;
+    // cache line 1 - 64bytes waste of space !
+    uint32_t m_nat_external_ipv4;       // NAT client IP
+    uint32_t m_nat_tcp_seq_diff_client; // support for firewalls that do TCP seq num randomization
+    uint32_t m_nat_tcp_seq_diff_server; // And some do seq num randomization for server->client also
+    uint16_t m_nat_external_port;       // NAT client port
+    uint16_t m_nat_pad[1];
+    const ClientCfgBase *m_client_cfg;
+    // Here comes the actual CGenNodeTimesync part (the difference is last 4 * 64 bits)
+    // uint32_t            m_src_idx;
+    // uint32_t            m_dest_idx;
+    // uint32_t            m_end_of_cache_line[6];
+    dsec_t timesync_last;
+    double t2;
+    double t3;
+    double t4;
+} __rte_cache_aligned;
+
+static_assert(sizeof(CGenNodeTimesync) == sizeof(CGenNode), "sizeof(CGenNodeTimesync) != sizeof(CGenNode)");
+
 #endif /* __TREX_STL_STREAM_NODE_H__ */
 

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -570,7 +570,7 @@ public:
         m_hdrh = false;
         m_latency_measurement = 0;
         m_timesync_method = 0;
-        m_timesync_period = 60;
+        m_timesync_interval = 0;
     }
 
     CParserOption(){
@@ -635,7 +635,7 @@ public:
     uint64_t        (*m_get_latency_timestamp)();
     double          (*m_timestamp_diff_to_dsec)(uint64_t);
     uint8_t         m_timesync_method;
-    uint32_t        m_timesync_period;
+    uint32_t        m_timesync_interval;
 
 
 public:


### PR DESCRIPTION
Adds a skeleton for time synchronisation mechanism.

A scheduler step `scTIMESYNC` is added in `CNodeGenerator` which is then used in `CNodeGenerator::flush_file_realtime` method to call `do_timesync` function, according to CGlobalInfo::m_options.m_timesync_period` and `CGlobalInfo::m_options.m_timesync_method`.

Time synchronisation methods would be implemented in `src/utils/utl_timesync.cpp` (as is `do_timesync`).