### PR TITLE
Do not try using mlx5 DPDK driver (for Mellanox)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /src/trex-core
 WORKDIR /src/trex-core
 
 RUN cd ./linux_dpdk && \
-    ./b configure && \
+    ./b configure --no-mlx=NO_MLX && \
     ./b build && \
     cd ../ && \
     cd ./linux && \


### PR DESCRIPTION
This is a tiny Docker image building improvement.

This image is not intended to support Mellanox mlx5 cards.  Adding `--no-mlx=NO_MLX` option prevents configure step from even trying.  This way configure runs a little bit faster and does not display any warning ("Warning: will use internal version of ibverbs. If you need to use Mellanox NICs, install OFED [...]")