### PR TITLE
Use nanonseconds in now_sec function when configured

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ static CSimpleOpt::SOption parser_options[] =
 
     { OPT_DRY_RUN,            "--dry",      SO_NONE },
 
-    
+
     SO_END_OF_OPTIONS
 };
 
@@ -370,6 +370,11 @@ static int parse_options(int argc,
     return 0;
 }
 
+void set_default_time_method(){
+  CGlobalInfo::m_options.m_now_sec = &now_sec_ticker;
+  CGlobalInfo::m_options.m_time_init = &time_init_ticker;
+}
+
 void set_default_mac_addr(){
 
     int i;
@@ -413,6 +418,7 @@ int main(int argc , char * argv[]){
         exit(-1);
     }
     set_default_mac_addr();
+    set_default_time_method();
 
 
     opt_type_e type = (opt_type_e) params["type"];

--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -6436,10 +6436,16 @@ COLD_FUNC int main_test(int argc , char * argv[]){
     if (CGlobalInfo::m_options.m_latency_measurement == CParserOption::LATENCY_METHOD_NANOS) {
         CGlobalInfo::m_options.m_get_latency_timestamp = &get_time_epoch_nanoseconds;
         CGlobalInfo::m_options.m_timestamp_diff_to_dsec = &ptime_convert_ns_dsec;
+        CGlobalInfo::m_options.m_now_sec = &now_sec_timer;
+        CGlobalInfo::m_options.m_time_init = &time_init_timer;
+
         printf("Using realtime (nanoseconds) timestamps in latency stream.\n");
     } else {
         CGlobalInfo::m_options.m_get_latency_timestamp = &os_get_hr_tick_64;
         CGlobalInfo::m_options.m_timestamp_diff_to_dsec = &ptime_convert_hr_dsec;
+        CGlobalInfo::m_options.m_now_sec = &now_sec_ticker;
+        CGlobalInfo::m_options.m_time_init = &time_init_ticker;
+
         printf("Using cpu ticks timestamps in latency stream.\n");
     }
 

--- a/src/os_time.h
+++ b/src/os_time.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include <stdint.h>
 #include <time.h>
 #include "pal_utl.h"
+#include "trex_global.h"
 
 uint32_t 	 os_get_time_msec();
 uint32_t 	 os_get_time_freq();
@@ -172,10 +173,19 @@ hr_time_t    os_get_hr_freq(void);
 
 extern  COsTimeGlobalData  timer_gd;
 
-static inline void time_init(){
+
+static inline void time_init_ticker(){
     timer_gd.m_start_time = os_get_hr_tick_64();
     timer_gd.m_freq       = (double)os_get_hr_freq();
     timer_gd.m_1_div_freq = 1.0/timer_gd.m_freq;
+}
+
+static inline void time_init_timer(){
+    timer_gd.m_start_time = get_time_epoch_nanoseconds();
+}
+
+static inline void time_init(){
+    CGlobalInfo::m_options.m_time_init();
 }
 
 
@@ -193,11 +203,20 @@ static inline dsec_t ptime_convert_ns_dsec(hr_time_t hrt){
     return static_cast<dsec_t>(static_cast<double>(hrt) / (1000 * 1000 * 1000));
 }
 
-
 /* should be fixed , need to move to high rez tick */
-static inline dsec_t now_sec(void){
+static inline dsec_t now_sec_ticker(void){
     hr_time_t d=os_get_hr_tick_64() - timer_gd.m_start_time;
-	return ( ptime_convert_hr_dsec(d) );
+    return ( ptime_convert_hr_dsec(d) );
+}
+
+static inline dsec_t now_sec_timer(void){
+    dsec_t d=get_time_epoch_nanoseconds() - timer_gd.m_start_time;
+	return (ptime_convert_ns_dsec(d));
+}
+
+static inline dsec_t now_sec(void){
+    dsec_t d = CGlobalInfo::m_options.m_now_sec();
+    return (d);
 }
 
 

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -637,6 +637,8 @@ public:
     uint8_t         m_timesync_method;
     uint32_t        m_timesync_period;
 
+    double          (*m_now_sec)();
+    void            (*m_time_init)();
 
 public:
     uint8_t *       get_src_mac_addr(int if_index){


### PR DESCRIPTION
NOTE: Let's consider first if we really need it. After recent discussions I think it's not really that much useful for us. If we decide to still have it in code, I'll rename config param and update comments.

What do you think @mateumann @MehTheHedgehog?