### PR TITLE
Stop timesync Tx stream when test (sim) finishes

### DIFF
--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -527,7 +527,7 @@ public:
         RX_MSG                  =16,  /* message to Rx core */
         STL_RX_FLUSH            =17,
 
-        TIMESYNC                =18,
+        TIMESYNC                =31,
     };
 
     /* flags MASKS*/

--- a/src/stx/common/trex_rx_core.cpp
+++ b/src/stx/common/trex_rx_core.cpp
@@ -465,8 +465,7 @@ CRxCore::enable_latency() {
         mngr_pair.second->enable_latency();
         // This is a sending part for time synchronisation.  Enable it only if `timesync-method`
         // is set and `timesync-interval` equals 0.
-        if ((CGlobalInfo::m_options.m_timesync_method != CParserOption::TIMESYNC_NONE) &&
-            (CGlobalInfo::m_options.m_timesync_interval == 0)) {
+        if (CGlobalInfo::m_options.is_timesync_rx_enabled()) {
             mngr_pair.second->enable_timesync(CGlobalInfo::m_options.m_timesync_method);
         }
     }
@@ -487,7 +486,7 @@ CRxCore::enable_astf_latency_fia(bool enable) {
 void
 CRxCore::disable_latency() {
     for (auto &mngr_pair : m_rx_port_mngr_map) {
-        if (CGlobalInfo::m_options.m_timesync_method != CParserOption::TIMESYNC_NONE) {
+        if (CGlobalInfo::m_options.is_timesync_rx_enabled()) {
             mngr_pair.second->disable_timesync();
         }
         mngr_pair.second->disable_latency();

--- a/src/stx/stl/trex_stl_dp_core.h
+++ b/src/stx/stl/trex_stl_dp_core.h
@@ -101,6 +101,9 @@ public:
         return m_event_id;
     }
 
+private:
+  template <typename T> void free_node(CDpOneStream &dp_stream, T *node);
+
 public:
 
     state_e                     m_state;
@@ -363,6 +366,25 @@ private:
                     TrexStreamsCompiledObj *comp,
                     double start_at_ts = 0);
 
+    void build_mbuf_from_packet(TrexStream * stream,
+                                pkt_dir_t dir,
+                                CGenNodeStateless *node);
+
+    void allocate_no_vm_node(TrexStream * stream,
+                             pkt_dir_t dir,
+                             CGenNodeStateless *node);
+
+    void allocate_vm_node(TrexStream * stream,
+                          pkt_dir_t dir,
+                          CGenNodeStateless *node);
+
+    void add_timesync_node(PerPortProfile *profile,
+                           uint32_t profile_id,
+                           TrexStream *stream,
+                           double start_at_ts = 0);
+
+    template <typename T> void push_one_stream(PerPortProfile *profile,
+                                               T *node);
 
     void replay_vm_into_cache(TrexStream * stream,
                               CGenNodeStateless *node);

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -705,10 +705,47 @@ static_assert(sizeof(CGenNodePCAP) == sizeof(CGenNode), "sizeof(CGenNodePCAP) !=
 
 /* this is a event for time synchronization. */
 struct CGenNodeTimesync : public CGenNodeBase {
+    friend class TrexStatelessDpCore;
+
+  public:
+    enum {
+        PTP_INVALID = 0,
+        PTP_WAIT,
+        PTP_SYNC,
+        PTP_FOLLOW_UP_MASTER,
+        PTP_DELAYED_REQ,
+        PTP_FOLLOW_UP_SLAVE,
+        PTP_DELAYED_RESP,
+        PTP_MARKED_FOR_FREE
+    };
+
+    /* cache line 0 */
+    /* important stuff here */
+    dsec_t timesync_last;
+    dsec_t m_next_time_offset;
+
+  private:
+    CGenNodeStateless::stream_state_t m_state;
+    uint8_t m_stream_type; // see TrexStream::STREAM_TYPE, stream_type_t
+    uint8_t m_ptp_state;
+    uint32_t m_ptp_slave_ip;
+    uint64_t m_pad_0[3];
+
+    /* cache line 1 */
+    /* this cache line would better be readonly but is not */
+    double m_ptp_t1;
+    double m_ptp_t2;
+    double m_ptp_t3;
+    double m_ptp_t4;
+    TrexStream *m_ref_stream_info;
+    uint8_t m_port_id;
+    uint32_t m_profile_id;
+    uint64_t m_pad_1[10];
+
   public:
     inline void init() {
         set_send_immediately(true);
-        m_state = PTP_WAIT;
+        m_ptp_state = PTP_WAIT;
     }
 
     inline void handle(CFlowGenListPerThread *thread) {
@@ -721,7 +758,7 @@ struct CGenNodeTimesync : public CGenNodeBase {
 #endif
         return;
 
-        switch (m_state) {
+        switch (m_ptp_state) {
         case PTP_WAIT:
             return;
             break;
@@ -736,39 +773,16 @@ struct CGenNodeTimesync : public CGenNodeBase {
         }
     }
 
-    dsec_t timesync_last;
+    inline CGenNodeStateless::stream_state_t get_state() { return m_state; }
 
-  private:
-    enum {
-        PTP_INVALID = 0,
-        PTP_WAIT,
-        PTP_SYNC,
-        PTP_FOLLOW_UP_MASTER,
-        PTP_DELAYED_REQ,
-        PTP_FOLLOW_UP_SLAVE,
-        PTP_DELAYED_RESP,
-        PTP_MARKED_FOR_FREE
-    };
+    inline bool is_mask_for_free() { return (m_state == CGenNodeStateless::ss_FREE_RESUSE ? true : false); }
 
-    /* cache line 0 */
-    /* important stuff here */
-    uint32_t m_slave_ip_addr;
-    uint8_t m_state;
+    inline void mark_for_free() { m_state = CGenNodeStateless::ss_FREE_RESUSE; }
 
-    double t1;
-    double t2;
-    double t3;
-    double t4;
-
-    /* pad to match the size of CGenNode */
-    uint8_t m_pad_end[57];
-
-    /* CACHE_LINE */
-    uint64_t m_pad3[8];
+    inline uint8_t get_stream_type() { return (m_stream_type); }
 
 } __rte_cache_aligned;
 
 static_assert(sizeof(CGenNodeTimesync) == sizeof(CGenNode), "sizeof(CGenNodeTimesync) != sizeof(CGenNode)");
 
 #endif /* __TREX_STL_STREAM_NODE_H__ */
-

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -714,6 +714,19 @@ public:
         return (  (m_run_flags &RUN_FLAGS_RXCHECK_CONST_TS)?true:false );
     }
 
+
+    inline bool is_timesync_enabled() {
+        return m_timesync_method != CParserOption::TIMESYNC_NONE;
+    }
+
+    inline bool is_timesync_tx_enabled() {
+        return is_timesync_enabled() && (m_timesync_interval > 0);
+    }
+
+    inline bool is_timesync_rx_enabled() {
+        return is_timesync_enabled() && (m_timesync_interval == 0);
+    }
+
     inline uint8_t get_l_pkt_mode(){
         return (m_l_pkt_mode);
     }


### PR DESCRIPTION
Timesync is a very strange stream.  It is very much connected with a latency stream, but should work the other way round.  TRex instance that is a transmitting part (Tx) for the latency stream should be a receiving part (Rx) for the timesync stream.  And vice-versa. Tx for timesync is also called a master, while Rx is called a slave.

This patch does some refactoring of when and how the timesync Tx node is initialized.  It has been moved to `TrexStatelessDpCore::add_stream` where latency streams are created.  A timesync Tx node is created quite similarly to a corresponding latency node.  This allows for it to be similarly stopped and removed by `stop_traffic` method.

This patch is a follow up for what @hhaim mentioned (codilime/trex-core#7) as a *restart issue*.