### PR TITLE
Add global TimesyncEngine singleton

### DIFF
--- a/linux/ws_main.py
+++ b/linux/ws_main.py
@@ -322,7 +322,7 @@ stx_src = SrcGroup(dir='src/stx/common',
                                      'trex_stack_legacy.cpp',
                                      'trex_rx_rpc_tunnel.cpp',
                                      'trex_rpc_cmds_common.cpp',
-                                     'trex_timesync.cpp',
+                                     'trex_rx_timesync.cpp',
                                      ])
 
 

--- a/linux_dpdk/ws_main.py
+++ b/linux_dpdk/ws_main.py
@@ -443,6 +443,7 @@ main_src = SrcGroup(dir='src',
              'bp_sim_tcp.cpp',
              'astf/astf_template_db.cpp',
              'stt_cp.cpp',
+             'trex_timesync.cpp',
              'trex_global.cpp',
              'trex_modes.cpp',
              'bp_sim.cpp',
@@ -585,7 +586,7 @@ stx_src = SrcGroup(dir='src/stx/common/',
         'trex_rx_rpc_tunnel.cpp',
         'trex_stack_linux_based.cpp',
         'trex_stx.cpp',
-        'trex_timesync.cpp',
+        'trex_rx_timesync.cpp',
     ])
 
 

--- a/src/common/Network/Packet/PTPPacket.h
+++ b/src/common/Network/Packet/PTPPacket.h
@@ -43,7 +43,8 @@ struct PTPPacket {
     uint16_t originSecondsMsb;
     uint32_t originSecondsLsb;
     uint32_t originNanoseconds;
-};
+} __attribute__((packed));
+
 static_assert(std::is_standard_layout<PTPPacket>::value, "PTPPacket must be a simple linear data structure.");
 
 struct PTPPacketSync : PTPPacket {};
@@ -77,7 +78,8 @@ struct PTPPacketDelayedResp {
     uint32_t originNanoseconds;
     uint64_t reqClockIdentity;
     uint16_t reqSourcePortId;
-};
+} __attribute__((packed));
+
 static_assert(std::is_standard_layout<PTPPacketDelayedResp>::value,
               "PTPPacketDelayedResp must be a simple linear data structure.");
 

--- a/src/stx/common/trex_rx_core.cpp
+++ b/src/stx/common/trex_rx_core.cpp
@@ -466,7 +466,8 @@ CRxCore::enable_latency() {
         // This is a sending part for time synchronisation.  Enable it only if `timesync-method`
         // is set and `timesync-interval` equals 0.
         if (CGlobalInfo::m_options.is_timesync_rx_enabled()) {
-            mngr_pair.second->enable_timesync(CGlobalInfo::m_options.m_timesync_method);
+            mngr_pair.second->enable_timesync(CGlobalInfo::get_timesync_engine());
+            assert(mngr_pair.second->m_timesync);
         }
     }
     

--- a/src/stx/common/trex_rx_port_mngr.h
+++ b/src/stx/common/trex_rx_port_mngr.h
@@ -29,9 +29,9 @@
 
 #include "trex_pkt.h"
 #include "trex_rx_feature_api.h"
+#include "trex_rx_timesync.h"
 #include "trex_stack_base.h"
 #include "trex_latency_counters.h"
-#include "trex_timesync.h"
 
 class CPortLatencyHWBase;
 class BPFFilter;
@@ -308,12 +308,13 @@ public:
     }
 
     /* timesync */
-    void enable_timesync(uint8_t timesync_method) {
-        m_timesync = new RXTimesync(timesync_method);
+    void enable_timesync(CTimesyncEngine *timesync_engine) {
+        m_timesync = new RXTimesync(timesync_engine);
         set_feature(TIMESYNC);
     }
 
     void disable_timesync() {
+        delete m_timesync;
         unset_feature(TIMESYNC);
     }
 

--- a/src/stx/common/trex_rx_timesync.cpp
+++ b/src/stx/common/trex_rx_timesync.cpp
@@ -1,4 +1,4 @@
-#include "trex_timesync.h"
+#include "trex_rx_timesync.h"
 
 #include "trex_global.h"
 
@@ -8,13 +8,13 @@
 // RXTimesync::RXTimesync() {}
 
 void RXTimesync::handle_pkt(const rte_mbuf_t *m, int port) {
-    if (m_timesync_method == CParserOption::TIMESYNC_PTP) {
+    if (m_timesync_method == TimesyncMethod::PTP) {
         printf("Syncing time with PTP method (slave side).\n");
 #ifdef _DEBUG
         printf("PTP time synchronisation is currently not supported (but we are working on that).\n");
 #endif
-        uint8_t ret = parse_ptp_pkt(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
-        printf("MATEUSZ parse_ptp_pkt returned %d\n", ret);
+        // uint8_t ret = parse_ptp_pkt(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
+        parse_ptp_pkt(rte_pktmbuf_mtod(m, uint8_t *), m->pkt_len);
     }
 }
 
@@ -43,23 +43,27 @@ TimesyncPacketParser_err_t RXTimesync::parse_ptp_pkt(uint8_t *pkt, uint16_t len)
     m_ptp_hdr->dump(stdout);
     pkt_offset += PTP_HDR_LEN;
 
-    // hexdump(pkt + pkt_offset, len - pkt_offset);
+    hexdump(pkt + pkt_offset, len - pkt_offset);
 
     switch (m_ptp_hdr->getMessageId()) {
     case PTPHeader::MessageType::SYNC:
         m_ptp_packet_sync = (PTPPacketSync *)(pkt + pkt_offset);
+        // m_timesync_engine->do_something();
         m_ptp_packet_sync->dump(stdout);
         break;
     case PTPHeader::MessageType::FOLLOW_UP:
         m_ptp_packet_fwup = (PTPPacketFollowUp *)(pkt + pkt_offset);
+        // m_timesync_engine->do_something();
         m_ptp_packet_fwup->dump(stdout);
         break;
     case PTPHeader::MessageType::DELAY_REQ:
         m_ptp_packet_dreq = (PTPPacketDelayedReq *)(pkt + pkt_offset);
+        // m_timesync_engine->do_something();
         m_ptp_packet_dreq->dump(stdout);
         break;
     case PTPHeader::MessageType::DELAY_RESP:
         m_ptp_packet_drsp = (PTPPacketDelayedResp *)(pkt + pkt_offset);
+        // m_timesync_engine->do_something();
         m_ptp_packet_drsp->dump(stdout);
         break;
     default:

--- a/src/stx/common/trex_rx_timesync.h
+++ b/src/stx/common/trex_rx_timesync.h
@@ -1,11 +1,14 @@
-#ifndef __TREX_TIMESYNC_H__
-#define __TREX_TIMESYNC_H__
+#ifndef __TREX_RX_TIMESYNC_H__
+#define __TREX_RX_TIMESYNC_H__
 
 #include "stl/trex_stl_fs.h"
+
+#include <trex_timesync.h>
 
 #include <common/Network/Packet/EthernetHeader.h>
 #include <common/Network/Packet/PTPHeader.h>
 #include <common/Network/Packet/PTPPacket.h>
+
 
 typedef enum TimesyncPacketParser_err {
     TIMESYNC_PARSER_E_OK = 0,
@@ -22,12 +25,16 @@ typedef enum TimesyncPacketParser_err {
     // TIMESYNC_PARSER_E_VLAN_NEEDED,
 } TimesyncPacketParser_err_t;
 
+
 /**************************************
  * RXTimesync
  *************************************/
 class RXTimesync {
   public:
-    RXTimesync(uint8_t timesync_method) { m_timesync_method = timesync_method; };
+    RXTimesync(CTimesyncEngine *engine) {
+        m_timesync_engine = engine;
+        m_timesync_method = engine->getTimesyncMethod();
+    };
 
     void handle_pkt(const rte_mbuf_t *m, int port);
 
@@ -38,7 +45,8 @@ class RXTimesync {
     void hexdump(const unsigned char *msg, uint16_t len); // TODO remove
 
   private:
-    uint8_t m_timesync_method;
+    CTimesyncEngine *m_timesync_engine;
+    TimesyncMethod m_timesync_method;
 
     uint8_t *m_start;
     uint16_t m_len;

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -747,8 +747,9 @@ struct CGenNodeTimesync : public CGenNodeBase {
     uint8_t m_port_id;
     uint32_t m_profile_id;
     rte_mbuf_t* m;
-    PTP::PTPEngine* engine;
-    uint64_t m_pad_1[4];
+    PTP::PTPEngine* engine;  // TODO: remove PTPEngine and move to CTimesyncEngine
+    CTimesyncEngine *m_timesync_engine;
+    uint64_t m_pad_1[3];
 
   public:
     inline void cleanup() {
@@ -760,10 +761,16 @@ struct CGenNodeTimesync : public CGenNodeBase {
 
     inline void init() {
         engine = new PTP::PTPEngine(m_port_id);
+        m_timesync_engine = CGlobalInfo::get_timesync_engine();
+        assert(m_timesync_engine);
         set_slow_path(true);
         set_send_immediately(true);
         m_ptp_state = PTP_WAIT;
         cleanup();
+    }
+
+    inline void teardown() {
+        m_timesync_engine = nullptr;
     }
 
     inline void handle(CFlowGenListPerThread *thread) {

--- a/src/trex_global.cpp
+++ b/src/trex_global.cpp
@@ -30,6 +30,7 @@ CParserOption       CGlobalInfo::m_options;
 CGlobalMemory       CGlobalInfo::m_memory_cfg;
 CPlatformSocketInfo CGlobalInfo::m_socket;
 CDpdkMode           CGlobalInfo::m_dpdk_mode;
+CTimesyncEngine     CGlobalInfo::m_timesync_engine;
 
 
 void CGlobalMemory::Dump(FILE *fd){

--- a/src/trex_timesync.cpp
+++ b/src/trex_timesync.cpp
@@ -1,0 +1,22 @@
+/*
+ Mateusz Neumann
+ Codilime Sp. z o.o.
+*/
+
+/*
+Copyright (c) 2019 Codilime Sp. z o.o.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "trex_timesync.h"

--- a/src/trex_timesync.h
+++ b/src/trex_timesync.h
@@ -1,0 +1,60 @@
+/*
+ Mateusz Neumann
+ Codilime Sp. z o.o.
+*/
+
+/*
+Copyright (c) 2019 Codilime Sp. z o.o.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef __TREX_TIMESYNC_H__
+#define __TREX_TIMESYNC_H__
+
+#include <stdint.h>
+#include <stdlib.h>
+
+enum struct TimesyncMethod : uint8_t { NONE = 0, PTP = 1 };
+
+enum struct TimesyncState : uint8_t { INIT = 0x31, WORK, WAIT, TERMINATE };
+
+/**
+ * Time synchronization engine
+ */
+class CTimesyncEngine {
+
+  public:
+    CTimesyncEngine() {
+        m_timesync_method = TimesyncMethod::NONE;
+        m_timesync_state = TimesyncState::INIT;
+    }
+
+    inline void setTimesyncMethod(TimesyncMethod method) { m_timesync_method = method; }
+    inline TimesyncMethod getTimesyncMethod() { return m_timesync_method; }
+
+    // TODO mateusz: write method that will preceed real PTP communication (a.k.a. advertisement, announcement) for PTP
+    //               slave to let know PTP master of its MAC/IP.
+
+    // TODO mateusz: write methods that are called upon receiving specific packages (i.e. PTP SYNC, PTP, FOLLOW UP etc.)
+
+  private:
+    TimesyncMethod m_timesync_method;
+    TimesyncState m_timesync_state;
+    timespec m_ptp_t1;
+    timespec m_ptp_t2;
+    timespec m_ptp_t3;
+    timespec m_ptp_t4;
+};
+
+#endif /* __TREX_TIMESYNC_H__ */


### PR DESCRIPTION
Create a time synchronization engine upon starting TRex.  Add a reference to
this object in RXTimesync and CGenNodeTimesync objects.