### PR TITLE
Optimize latency calculation

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -1963,7 +1963,10 @@ HOT_FUNC int CCoreEthIFStateless::send_node_flow_stat(rte_mbuf *m, CGenNodeState
     if (hw_id >= MAX_FLOW_STATS) {
         fsp_head->time_stamp = CGlobalInfo::m_options.get_latency_timestamp();
         if (CGlobalInfo::m_options.is_timesync_enabled()) {
-            fsp_head->time_stamp += static_cast<uint64_t>(CGlobalInfo::get_timesync_engine()->getDelta(lp_port->m_port->get_tvpid()));
+            // do not send latency packets unless we are synchronized
+            if (!CGlobalInfo::m_timesync_engine.isSlaveSynchronized())
+                return -1;
+            fsp_head->time_stamp += CGlobalInfo::get_timesync_engine()->getDelta(lp_port->m_port->get_tvpid());
         }
         send_pkt_lat(lp_port, mi, lp_stats);
     } else {

--- a/src/stx/common/trex_latency_counters.cpp
+++ b/src/stx/common/trex_latency_counters.cpp
@@ -227,10 +227,18 @@ RXLatency::handle_correct_flow(
     uint16_t hw_id = fsp_head->hw_id;
     m_rx_pg_stat_payload[hw_id].add_pkts(1);
     m_rx_pg_stat_payload[hw_id].add_bytes(pkt_len + 4); // +4 for ethernet CRC
-    // calculate difference of floats as (hr_time_now - fsp_head->time_stamp) could be < 0
-    dsec_t ctime = CGlobalInfo::m_options.timestamp_diff_to_dsec(hr_time_now) -
-                   CGlobalInfo::m_options.timestamp_diff_to_dsec(fsp_head->time_stamp);
+    if (!has_valid_timestamps(fsp_head, hr_time_now))
+        return;
+    uint64_t d = (hr_time_now - fsp_head->time_stamp);
+    dsec_t ctime = CGlobalInfo::m_options.timestamp_diff_to_dsec(d);
     curr_rfc2544->add_sample(ctime);
+}
+
+inline bool
+RXLatency::has_valid_timestamps(
+        flow_stat_payload_header *fsp_head,
+        hr_time_t hr_time_now) {
+    return hr_time_now >= fsp_head->time_stamp;
 }
 
 void

--- a/src/stx/common/trex_latency_counters.h
+++ b/src/stx/common/trex_latency_counters.h
@@ -127,6 +127,9 @@ private:
         CRFC2544Info *curr_rfc2544,
         uint32_t pkt_len,
         hr_time_t hr_time_now);
+    inline bool has_valid_timestamps(
+        flow_stat_payload_header *fsp_head,
+        hr_time_t hr_time_now);
     void check_seq_number_and_update_stats(
         flow_stat_payload_header *fsp_head,
         CRFC2544Info *curr_rfc2544);

--- a/src/stx/common/trex_rx_timesync.cpp
+++ b/src/stx/common/trex_rx_timesync.cpp
@@ -5,7 +5,6 @@
 /**************************************
  * RXTimesync
  *************************************/
-// RXTimesync::RXTimesync() {}
 
 void RXTimesync::handle_pkt(const rte_mbuf_t *m, int port) {
     if (m_timesync_engine->getTimesyncMethod() == TimesyncMethod::PTP) {

--- a/src/time_histogram.cpp
+++ b/src/time_histogram.cpp
@@ -184,8 +184,8 @@ dsec_t  CTimeHistogram::get_average_latency() {
 }
 
 
-int64_t CTimeHistogram::get_usec(dsec_t d) {
-    return (int64_t)(d*1000000.0);
+uint32_t CTimeHistogram::get_usec(dsec_t d) {
+    return (uint32_t)(d*1000000.0);
 }
 
 void CTimeHistogram::DumpWinMax(FILE *fd) {
@@ -220,7 +220,7 @@ void CTimeHistogram::Dump(FILE *fd) {
     for (j = 0; j < HISTOGRAM_SIZE_LOG; j++) {
         for (i = 0; i < HISTOGRAM_SIZE; i++) {
             if (m_hcnt[j][i] > 0) {
-                fprintf (fd," h[%u]  :  %llu \n",(base*(i+1)),(long long)m_hcnt[j][i]);
+                fprintf (fd," h[%u]  :  %llu \n",(base*(i+1)),(unsigned long long)m_hcnt[j][i]);
             }
         }
         base=base*10;
@@ -284,7 +284,7 @@ void CTimeHistogram::dump_json(Json::Value & json, bool add_histogram) {
                 if (m_hcnt[j][i] > 0) {
                     std::string key = static_cast<std::ostringstream*>( &(std::ostringstream()
                                                                           << int(base * (i + 1)) ) )->str();
-                    json["histogram"][key] = Json::Value::Int64(m_hcnt[j][i]);
+                    json["histogram"][key] = Json::Value::UInt64(m_hcnt[j][i]);
                 }
             }
             base = base * 10;
@@ -332,7 +332,7 @@ CTimeHistogram CTimeHistogram::operator+= (const CTimeHistogram& in) {
     }
     this->m_total_cnt += in.m_total_cnt;
     this->m_total_cnt_high += in.m_total_cnt_high;
-    int64_t new_sum = 0;
+    uint64_t new_sum = 0;
     for (uint8_t i = 0; i < 2; i++) {
         new_sum += this->m_period_data[i].get_sum();
     }

--- a/src/time_histogram.h
+++ b/src/time_histogram.h
@@ -59,7 +59,7 @@ class CTimeHistogramPerPeriodData {
     void update_sum(dsec_t dt) {
         m_sum += dt * 1000000;
     }
-    inline int64_t get_sum() {return m_sum;}
+    inline uint64_t get_sum() {return m_sum;}
     inline uint64_t get_cnt() {return m_cnt;}
     inline uint64_t get_high_cnt() {return m_cnt_high;}
     inline dsec_t get_max() {return m_max;}
@@ -76,7 +76,7 @@ class CTimeHistogramPerPeriodData {
 
 
  private:
-    int64_t m_sum; // Sum of samples
+    uint64_t m_sum; // Sum of samples
     uint64_t m_cnt;  // Number of samples
     uint64_t m_cnt_high;  // Number of samples above configured threshold
     dsec_t   m_max;  // Max sample
@@ -118,7 +118,7 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const CTimeHistogram& in);
 
 private:
-    int64_t get_usec(dsec_t d);
+    uint32_t get_usec(dsec_t d);
     double  get_cur_average();
     void  update_average(CTimeHistogramPerPeriodData &period_elem);
     inline uint8_t get_read_period_index() {
@@ -143,7 +143,7 @@ private:
     uint32_t m_win_cnt;
     uint32_t m_hot_max;
     dsec_t   m_max_ar[HISTOGRAM_QUEUE_SIZE]; // Array of maximum latencies for previous periods
-    int64_t  m_hcnt[HISTOGRAM_SIZE_LOG][HISTOGRAM_SIZE];
+    uint64_t m_hcnt[HISTOGRAM_SIZE_LOG][HISTOGRAM_SIZE];
     // Hdr histogram instance
     hdr_histogram *m_hdrh;
 };

--- a/src/trex_timesync.cpp
+++ b/src/trex_timesync.cpp
@@ -33,7 +33,11 @@ inline uint64_t timespecToTimestamp(timespec ts) { return ((uint64_t)ts.tv_sec *
  * CTimesyncEngine
  */
 
-CTimesyncEngine::CTimesyncEngine() { m_timesync_method = TimesyncMethod::NONE; }
+CTimesyncEngine::CTimesyncEngine() {
+    setTimesyncMethod(TimesyncMethod::NONE);
+    setTimesyncMaster(false);
+    m_is_slave_synchronized = false;
+}
 
 // PTP Slave's code //////////////////////////////////////////////
 
@@ -129,6 +133,7 @@ int64_t CTimesyncEngine::evalDelta(int port, uint16_t sequence_id) {
                     2;
     setDelta(port, delta);
     cleanupSequencesBefore(port, data->t2);
+    m_is_slave_synchronized = true;
     return delta;
 }
 
@@ -138,14 +143,6 @@ void CTimesyncEngine::setDelta(int port, int64_t delta) {
         m_deltas[port] = delta;
     } else {
         m_deltas.insert({port, delta});
-    }
-}
-
-int64_t CTimesyncEngine::getDelta(int port) {
-    try {
-        return m_deltas.at(port);
-    } catch (const std::out_of_range &e) {
-        return 0;
     }
 }
 

--- a/src/trex_timesync.h
+++ b/src/trex_timesync.h
@@ -69,20 +69,22 @@ class CTimesyncEngine {
     void setTimesyncMethod(TimesyncMethod method) { m_timesync_method = method; }
     TimesyncMethod getTimesyncMethod() { return m_timesync_method; }
 
-    void setTimesyncMaster(bool is_master) { m_is_master = is_master; }
-    bool isTimesyncMaster() { return m_is_master; }
+    inline void setTimesyncMaster(bool is_master) { m_is_master = is_master; }
+    inline bool isTimesyncMaster() { return m_is_master; }
+
+    inline bool isSlaveSynchronized() { return m_is_slave_synchronized; }
 
     void setSequenceId(uint16_t sequence_id) {
         if (m_is_master)
             m_sequence_id = sequence_id;
     }
-    uint16_t getSequenceId() {
+    inline uint16_t getSequenceId() {
         if (m_is_master)
             return m_sequence_id;
         else
             return 0;
     }
-    uint16_t nextSequenceId() {
+    inline uint16_t nextSequenceId() {
         if (m_is_master)
             return ++m_sequence_id;
         else
@@ -103,7 +105,13 @@ class CTimesyncEngine {
 
     int64_t evalDelta(int port, uint16_t sequence_id);
     void setDelta(int port, int64_t delta);
-    int64_t getDelta(int port);
+    inline int64_t getDelta(int port) {
+        try {
+            return m_deltas.at(port);
+        } catch (const std::out_of_range &e) {
+            return 0;
+        }
+    }
 
     void pushNextMessage(int port, uint16_t sequence_id, PTP::Field::message_type type, timespec time,
                          PTP::Field::src_port_id_field source_port_id = {});
@@ -126,6 +134,7 @@ class CTimesyncEngine {
   private:
     TimesyncMethod m_timesync_method;
     bool m_is_master;
+    bool m_is_slave_synchronized;
     uint16_t m_sequence_id;
     std::unordered_map<int, CTimesyncSequences_t> m_sequences_per_port;
     std::unordered_map<int, CTimesyncPTPPacketQueue_t> m_send_queue_per_port;


### PR DESCRIPTION
This patch applies in situations where we measure latency and use time
synchronization.  TRex Tx will not send latency packets unless instances are
synchronized (at least one successful PTP communication flow took place).
TRex Rx will not use latency packets that have a timestamp greater than current
time in latency and jitter calculations.