### PR TITLE
Use PTP delta to adjust timestamping clock

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -1997,7 +1997,8 @@ HOT_FUNC int CCoreEthIFStateless::send_node_flow_stat(rte_mbuf *m, CGenNodeState
             return -1;
         uint8_t m_port_id = lp_port->m_port->get_tvpid();
         fsp_head->time_stamp = CGlobalInfo::m_options.get_latency_timestamp(m_port_id);
-        if (CGlobalInfo::m_options.is_timesync_enabled()) {
+        if (CGlobalInfo::m_options.is_timesync_enabled() &&
+            !(CGlobalInfo::get_timesync_engine()->isHardwareClockAdjusted(m_port_id))) {
             fsp_head->time_stamp += CGlobalInfo::get_timesync_engine()->getDelta(m_port_id);
         }
         send_pkt_lat(lp_port, mi, lp_stats);

--- a/src/pal/linux/mbuf.h
+++ b/src/pal/linux/mbuf.h
@@ -287,6 +287,12 @@ static inline int rte_delay_us(unsigned int us) {
     return usleep(us);
 }
 
+// this method should only run with hardware clocks on NICs
+static inline int rte_eth_timesync_adjust_time(uint16_t port_id, int64_t delta)
+{
+    return -1;
+}
+
 /**
  * Get the headroom in a packet mbuf.
  *


### PR DESCRIPTION
If hardware timestamping is enabled (which means NIC's clock is used),
use PTP delta not to offset latency packets' timestamps, but to adjust
hardware clock.

This adjustment happens each time PTP sequence is completed.