### PR TITLE
Use proper port for the PTP communication

### DIFF
--- a/src/bp_sim.h
+++ b/src/bp_sim.h
@@ -841,7 +841,7 @@ public:
     }
 
     inline pkt_dir_t get_mbuf_cache_dir(){
-        return ((pkt_dir_t)( m_flags &1));
+        return ((pkt_dir_t)( m_flags &NODE_FLAGS_DIR));
     }
 
     inline void set_cache_mbuf(rte_mbuf_t * m){

--- a/src/stx/stl/trex_stl_dp_core.cpp
+++ b/src/stx/stl/trex_stl_dp_core.cpp
@@ -1508,6 +1508,7 @@ TrexStatelessDpCore::add_timesync_node(PerPortProfile *profile,
     // Get dest and src MAC
     pkt_dir_t pkt_dir = m_core->m_node_gen.m_v_if->port_id_to_dir(stream->m_port_id);
     m_core->m_node_gen.m_v_if->update_mac_addr_from_global_cfg(pkt_dir, reinterpret_cast<uint8_t*>(&(node->m_mac_addr)));
+    node->set_mbuf_cache_dir(pkt_dir);
 
     if (stream->m_self_start) {
         node->m_state = CGenNodeStateless::ss_ACTIVE;

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -331,7 +331,7 @@ public:
     }
 
     inline pkt_dir_t get_mbuf_cache_dir(){
-        return ((pkt_dir_t)( m_flags &1));
+        return ((pkt_dir_t)( m_flags &NODE_FLAGS_DIR));
     }
 
     inline void set_cache_mbuf(rte_mbuf_t * m){
@@ -773,7 +773,7 @@ struct CGenNodeTimesync : public CGenNodeBase {
     }
 
     inline pkt_dir_t get_mbuf_cache_dir(){
-        return ((pkt_dir_t)( m_flags &1));
+        return ((pkt_dir_t)( m_flags &NODE_FLAGS_DIR));
     }
 
     inline void handle(CFlowGenListPerThread *thread) {

--- a/src/stx/stl/trex_stl_stream_node.h
+++ b/src/stx/stl/trex_stl_stream_node.h
@@ -764,6 +764,18 @@ struct CGenNodeTimesync : public CGenNodeBase {
         m_timesync_engine = nullptr;
     }
 
+    inline void set_mbuf_cache_dir(pkt_dir_t  dir){
+        if (dir) {
+            m_flags |=NODE_FLAGS_DIR;
+        }else{
+            m_flags &=~NODE_FLAGS_DIR;
+        }
+    }
+
+    inline pkt_dir_t get_mbuf_cache_dir(){
+        return ((pkt_dir_t)( m_flags &1));
+    }
+
     inline void handle(CFlowGenListPerThread *thread) {
         if (timesync_last + static_cast<double>(CGlobalInfo::m_options.m_timesync_interval) < now_sec()) {
             if (hardware_timestamping_enabled) {


### PR DESCRIPTION
PTP was always handled by the first delared port.  This is no longer
an issue, as this patch fixes that behaviour.